### PR TITLE
design: 모바일 view 100vh가 작동되게 height 재설정

### DIFF
--- a/frontend/src/sass/base/_typography.scss
+++ b/frontend/src/sass/base/_typography.scss
@@ -85,11 +85,13 @@ body {
     min-width: 320px;
     max-width: 479px;
     height: 100%;
+    height: calc(var(--vh, 1vh) * 100);
   }
   @include respond(smartphones-land) {
     min-width: 480px;
     max-width: 599px;
     height: 100%;
+    height: calc(var(--vh, 1vh) * 100);
   }
 
   @include respond(tab-port) {


### PR DESCRIPTION
# 작업 내용 요약
- 모바일 링크 탭으로 인해 100vh view port가 적상적으로 작동되지 않아 mobile responsive web 설정에서 이를 작업