### PR TITLE
프로필 이미지 품질을 해결하기 위해 이미지 aspect ratio 작업

### DIFF
--- a/frontend/src/components/Card/Card.jsx
+++ b/frontend/src/components/Card/Card.jsx
@@ -62,8 +62,9 @@ const CardView = ({ bottomProps, topProps, popupStyle }) => {
 const CardWrap = styled.div`
   height: 100%;
   flex-direction: column;
-  width: 82%;
-
+  width: auto;
+  position: relative;
+  aspect-ratio: 9/16;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/components/Card/MyCard.jsx
+++ b/frontend/src/components/Card/MyCard.jsx
@@ -51,8 +51,11 @@ const MyCardWrap = styled.div`
   transform: translate(-50%, -50%);
 
   flex-direction: column;
-  width: 85%;
+  width: auto;
+  aspect-ratio: 9/ 16;
   height: 72.38%;
+  border-radius: 12px;
+  background-color: white;
 
   display: flex;
   justify-content: center;

--- a/frontend/src/components/Card/top/CardTop.scss
+++ b/frontend/src/components/Card/top/CardTop.scss
@@ -1,6 +1,7 @@
 .card__top {
   height: 76%;
-  width: 100%;
+  width: auto;
+  aspect-ratio: 4/5;
 
   .blur-load {
     width: 100%;

--- a/frontend/src/components/Card/top/CardTop.scss
+++ b/frontend/src/components/Card/top/CardTop.scss
@@ -1,8 +1,7 @@
 .card__top {
   height: 76%;
-  width: auto;
+  width: 100%;
   aspect-ratio: 4/5;
-
   .blur-load {
     width: 100%;
     height: 100%;

--- a/frontend/src/components/CardColumn/UserCardColumn.jsx
+++ b/frontend/src/components/CardColumn/UserCardColumn.jsx
@@ -1,5 +1,5 @@
-import React, { memo, forwardRef } from "react";
-import { styled } from "styled-components";
+import React, { memo, forwardRef } from 'react';
+import { styled } from 'styled-components';
 
 const UserCardColumn = memo(
   forwardRef(({ user, checkedState, popupHandler, imageSrc }, ref) => {
@@ -22,14 +22,14 @@ const UserCardColumnView = forwardRef(
     return (
       <ColumnBig ref={ref}>
         <input
-          type="checkbox"
+          type='checkbox'
           name={id}
           id={id}
           checked={checkedState}
           onChange={popupHandler}
         />
         <ColumnLabel htmlFor={id}>
-          <UserColumnProfile loading="lazy" src={imageSrc} alt="save-profile" />
+          <UserColumnProfile loading='lazy' src={imageSrc} alt='save-profile' />
 
           <UserColumnDescWrap>
             <UserColumnName>{name}</UserColumnName>
@@ -44,6 +44,7 @@ const UserCardColumnView = forwardRef(
 const ColumnBig = styled.div`
   display: flex;
   width: 47%;
+  aspect-ratio: 9 / 16;
   height: 45%;
   flex-direction: column;
   margin: 0.7rem 0.3rem;
@@ -72,6 +73,7 @@ const ColumnLabel = styled.label`
 const UserColumnProfile = styled.img`
   width: 100%;
   height: 75%;
+  aspect-ratio: 4/ 5;
   display: flex;
   align-items: center;
   border-radius: 8px;

--- a/frontend/src/screens/home/content/HomeContent.jsx
+++ b/frontend/src/screens/home/content/HomeContent.jsx
@@ -89,8 +89,7 @@ const HomeContent = ({
 };
 
 export const HomeWrap = styled.div`
-  position: absolute;
-  height: 94%;
+  height: 98%;
   width: 100%;
   flex-direction: column;
   display: flex;

--- a/frontend/src/screens/profileEdit/personalInfoEdit/imageEdit/PersonalImageEdit.jsx
+++ b/frontend/src/screens/profileEdit/personalInfoEdit/imageEdit/PersonalImageEdit.jsx
@@ -20,7 +20,7 @@ const PersonalImageEdit = ({
   const [imgSrc, setImgSrc] = useState('');
   const [crop, setCrop] = useState('');
   const [completedCrop, setCompletedCrop] = useState('');
-  const aspect = 0.67 / 1;
+  const aspect = 4 / 5;
   /** 이미지를 로드하여 자동으로 crop해주는 함수 */
   const onImageLoad = (e) => {
     if (aspect) {
@@ -35,8 +35,8 @@ const PersonalImageEdit = ({
       makeAspectCrop(
         {
           unit: 'px',
-          width: 337.87,
-          height: 503.31,
+          width: 1080,
+          height: 1350,
         },
         aspect,
         mediaWidth,
@@ -73,7 +73,7 @@ const PersonalImageEdit = ({
     const options = {
       maxSizeMB: 5,
       fileType: 'image/jpeg',
-      maxWidthOrHeight: 620,
+      maxWidthOrHeight: 1350,
       useWebWorker: true,
       quality: 1.0,
     };

--- a/frontend/src/screens/register/afterRegister/ImageRegister.jsx
+++ b/frontend/src/screens/register/afterRegister/ImageRegister.jsx
@@ -16,7 +16,7 @@ const ImageRegister = ({ handleNext, dispatch }) => {
   const [imgSrc, setImgSrc] = useState('');
   const [crop, setCrop] = useState('');
   const [completedCrop, setCompletedCrop] = useState('');
-  const aspect = 0.67 / 1;
+  const aspect = 4 / 5;
   /** 이미지를 로드하여 자동으로 crop해주는 함수 */
   const onImageLoad = (e) => {
     if (aspect) {
@@ -31,8 +31,8 @@ const ImageRegister = ({ handleNext, dispatch }) => {
       makeAspectCrop(
         {
           unit: 'px',
-          width: 337.87,
-          height: 503.31,
+          width: 1080,
+          height: 1350,
         },
         aspect,
         mediaWidth,
@@ -67,7 +67,7 @@ const ImageRegister = ({ handleNext, dispatch }) => {
     const options = {
       maxSizeMB: 5,
       fileType: 'image/jpeg',
-      maxWidthOrHeight: 620,
+      maxWidthOrHeight: 1350,
       useWebWorker: true,
       quality: 1.0,
     };


### PR DESCRIPTION
# 작업 내용 요약
### 홈 화면, 저장 화면 등 유저 프로필 품질이 떨어지는 문제 발생
- 유저마다 다른 모바일 사이즈로 인해 생기는 비균등한 aspect ratio가 생겼음. 해당 이유는 UI element에  rem 단위로만 의존하여 생긴 문제이기 때문에  aspect ratio를 넣어 프로필 이미지는 무조건 4 / 5 ratio를 프로필과 유저 설명문이 적힌 전체 UI는 9 / 16 ratio를 유지할 수 있게 작업.
- 변경된 aspect ratio에 따라 프로필 이미지 resizing도 이에 맞게 4 / 5 ratio로 설정하여 작업. 